### PR TITLE
feat: add server status tracking, retries, and cron sync jobs

### DIFF
--- a/navari_frappehr_biostar/controllers/biostar_calls.py
+++ b/navari_frappehr_biostar/controllers/biostar_calls.py
@@ -1,7 +1,7 @@
 import frappe
 from .utils.biostar_connector import BiostarConnector
 from frappe.utils.password import get_decrypted_password
-from frappe.utils import getdate
+from frappe.utils import getdate, add_days
 
 SETTINGS_DOCTYPE = "Biostar Settings"
 
@@ -35,6 +35,32 @@ def get_employee_checkins(start_date, end_date, employees=None):
     biostar.format_attendance_logs()
 
 
+@frappe.whitelist()
 def add_checkin_logs_for_current_day():
-    today = getdate().strftime("%Y-%m-%d")
-    return get_employee_checkins(today, today)
+    start_date = getdate().strftime("%Y-%m-%d")
+    end_date = start_date
+    return get_employee_checkins(start_date, end_date)
+
+
+def add_checkin_logs_for_date_range():
+    last_server_status = frappe.db.get_value(
+        "Biostar Settings", "Biostar Settings", "last_server_status"
+    )
+
+    if last_server_status == "Online":
+        frappe.log_error("Server was Online", "Skipping cron job")
+        return
+
+    start_date = add_days(getdate(), -1).strftime("%Y-%m-%d")
+    end_date = start_date
+    return get_employee_checkins(start_date, end_date)
+
+
+@frappe.whitelist()
+def check_for_yesterday_logs():
+    add_checkin_logs_for_date_range()
+
+
+@frappe.whitelist()
+def check_for_yesterday_logs_again():
+    add_checkin_logs_for_date_range()

--- a/navari_frappehr_biostar/controllers/utils/biostar_connector.py
+++ b/navari_frappehr_biostar/controllers/utils/biostar_connector.py
@@ -18,7 +18,41 @@ class BiostarConnector:
     def get_biostar_settings(self):
         return frappe.get_doc("Biostar Settings")
 
+    def check_server_status(self):
+        try:
+            response = requests.get(self.base_url, timeout=5, verify=False)
+            response.raise_for_status()
+            return True
+        except requests.RequestException as e:
+            frappe.log_error("Biostar Server Connection Error", str(e))
+            system_managers = frappe.get_all(
+                "Has Role",
+                filters={"role": "System Manager", "parenttype": "User"},
+                pluck="parent",
+            )
+            if frappe.db.get_value("Email Account", {"default_outgoing": 1}, "name"):
+                for user in system_managers:
+                    frappe.sendmail(
+                        recipients=[user],
+                        subject="Biostar Server Connection Error",
+                        message=_(
+                            "Unable to connect to Biostar server. Please ensure it is online."
+                        ),
+                    )
+            return False
+
     def login(self):
+        # Check if the server is online and reachable
+        if not self.check_server_status():
+            frappe.db.set_value(
+                "Biostar Settings", "Biostar Settings", "last_server_status", "Offline"
+            )
+            return
+
+        frappe.db.set_value(
+            "Biostar Settings", "Biostar Settings", "last_server_status", "Online"
+        )
+
         login_url = f"{self.base_url}/login"
         request_body = {
             "notification_token": "string",

--- a/navari_frappehr_biostar/hooks.py
+++ b/navari_frappehr_biostar/hooks.py
@@ -16,10 +16,7 @@ fixtures = [
             [
                 "name",
                 "in",
-                (
-                    "Employee-custom_last_attendance_sync_date",
-                  
-                ),
+                ("Employee-custom_last_attendance_sync_date",),
             ]
         ],
     },
@@ -44,8 +41,8 @@ fixtures = [
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-doctype_js = {"Employee" : "public/js/fetch_employee_checkins.js"}
-doctype_list_js = {"Employee" : "public/js/fetch_list.js"}
+doctype_js = {"Employee": "public/js/fetch_employee_checkins.js"}
+doctype_list_js = {"Employee": "public/js/fetch_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
@@ -243,9 +240,15 @@ doctype_list_js = {"Employee" : "public/js/fetch_list.js"}
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
 scheduler_events = {
-	
- "cron":{
-      "10 23 * * *":["navari_frappehr_biostar.controllers.biostar_calls.add_checkin_logs_for_current_day"],  
- },
+    "cron": {
+        "10 23 * * *": [
+            "navari_frappehr_biostar.controllers.biostar_calls.add_checkin_logs_for_current_day"
+        ],
+        "0 3 * * *": [
+            "navari_frappehr_biostar.controllers.biostar_calls.check_for_yesterday_logs"
+        ],
+        "30 5 * * *": [
+            "navari_frappehr_biostar.controllers.biostar_calls.check_for_yesterday_logs_again"
+        ],
+    },
 }
-

--- a/navari_frappehr_biostar/navari_frappehr_biostar/doctype/biostar_settings/biostar_settings.json
+++ b/navari_frappehr_biostar/navari_frappehr_biostar/doctype/biostar_settings/biostar_settings.json
@@ -15,6 +15,7 @@
   "active",
   "fetch_attendance_logs_section",
   "start_date",
+  "last_server_status",
   "column_break_vwvl",
   "end_date"
  ],
@@ -71,12 +72,20 @@
    "fieldname": "active",
    "fieldtype": "Check",
    "label": "Active"
+  },
+  {
+   "default": "Online",
+   "fieldname": "last_server_status",
+   "fieldtype": "Select",
+   "label": "Last Server Status",
+   "options": "Online\nOffline",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-09 10:49:21.677739",
+ "modified": "2025-09-02 16:14:44.570354",
  "modified_by": "Administrator",
  "module": "Navari Frappehr Biostar",
  "name": "Biostar Settings",
@@ -93,6 +102,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
- Add `last_server_status` (Online/Offline, read-only) to `Biostar Settings`
- Check Biostar connectivity before login; persist status; email System Managers on failure
- Add cron jobs: daily current-day sync at 23:10; yesterday retries at 03:00 and 05:30
- Expose whitelisted endpoints for current day and yesterday retry syncs
- Minor cleanup in hooks and date handling